### PR TITLE
Depend on the Swagger Plugin rather than including it.

### DIFF
--- a/src/main/assembly/dist-assembly.xml
+++ b/src/main/assembly/dist-assembly.xml
@@ -30,18 +30,6 @@
                 <include>com.smartbear:readyapi-swaggerhub-plugin</include>
             </includes>
         </dependencySet>
-        <dependencySet>
-            <unpack>true</unpack>
-            <unpackOptions>
-                <excludes>
-                    <exclude>com/smartbear/swagger/PluginConfig.class</exclude>
-                </excludes>
-            </unpackOptions>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>com.smartbear:soapui-swagger-plugin</include>
-            </includes>
-        </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>

--- a/src/main/java/com/smartbear/plugins/swaggerhub/PluginConfig.java
+++ b/src/main/java/com/smartbear/plugins/swaggerhub/PluginConfig.java
@@ -2,10 +2,15 @@ package com.smartbear.plugins.swaggerhub;
 
 import com.eviware.soapui.plugins.PluginAdapter;
 import com.eviware.soapui.plugins.PluginConfiguration;
+import com.eviware.soapui.plugins.PluginDependencies;
+import com.eviware.soapui.plugins.PluginDependency;
 
 @PluginConfiguration(groupId = "com.smartbear.plugins", name = "SwaggerHub ReadyAPI Plugin", version = "1.0.0",
         autoDetect = true, description = "Integrates Ready API with SwaggerHub",
         infoUrl = "")
+@PluginDependencies({
+        @PluginDependency(groupId = "com.smartbear.soapui.plugins", name = "Swagger Plugin", minimumVersion = "2.1.3"),
+})
 public class PluginConfig extends PluginAdapter {
 
     public final static String SWAGGERHUB_URL = "https://swaggerhub.com";


### PR DESCRIPTION
Avoid problems like this:
![duplicate importers](https://cloud.githubusercontent.com/assets/1818806/10185616/557df062-674a-11e5-8db8-697c868327c9.png)

If not installed already the Swagger Plugin will be installed when the SwaggerHub Plugin is installed.
